### PR TITLE
Allow PluginRegistry to resolve fully qualified type names

### DIFF
--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+
+import draccus
+
+
+def test_plugin_registry_decode_fully_qualified_name():
+    from tests.draccus_choice_plugins.gpt import GptConfig
+    from tests.draccus_choice_plugins.model_config import ModelConfig
+
+    config = draccus.decode(
+        ModelConfig,
+        {
+            "type": "tests.draccus_choice_plugins.gpt.GptConfig",
+            "layers": 12,
+            "attn_pdrop": 0.2,
+        },
+    )
+
+    assert config == GptConfig(12, 0.2)


### PR DESCRIPTION
## Summary
- allow PluginRegistry lookups to import fully-qualified class names when they are not registered aliases
- add a regression test that decodes a plugin using its fully qualified class name

## Testing
- pytest tests/test_plugin_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68dcb3b9ccbc8331a12af84cf72c25c8